### PR TITLE
Fix custom targeting not being sent with adRequest

### DIFF
--- a/RNDFPBanner.js
+++ b/RNDFPBanner.js
@@ -25,8 +25,8 @@ export default class DFPBanner extends React.Component {
   }
 
   render() {
-    const { adUnitID, testDeviceID, dimensions, customTargeting, style, didFailToReceiveAdWithError, admobDispatchAppEvent } = this.props;
-    let { bannerSize, adSizes } = this.props;
+    const { adUnitID, testDeviceID, dimensions, style, didFailToReceiveAdWithError, admobDispatchAppEvent } = this.props;
+    let { bannerSize, adSizes, customTargeting } = this.props;
 
     // Dimensions gets highest priority
     if (dimensions && dimensions.width && dimensions.height) {
@@ -42,6 +42,10 @@ export default class DFPBanner extends React.Component {
     // Default to something if nothing is set
     if (!bannerSize && (!dimensions || !dimensions.width || !dimensions.height) && (!adSizes || !adSizes.length > 0)) {
        bannerSize = 'smartBannerPortrait';
+    }
+
+    if (!customTargeting || Object.keys(customTargeting).length === 0) {
+        customTargeting = {}
     }
 
     return (

--- a/android/src/main/java/com/reactlibrary/RNDfpReactViewGroup.java
+++ b/android/src/main/java/com/reactlibrary/RNDfpReactViewGroup.java
@@ -1,0 +1,35 @@
+package com.reactlibrary;
+
+import android.content.Context;
+
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.views.view.ReactViewGroup;
+
+/**
+ * Created by jamesmorton on 2018-01-30.
+ */
+
+public class RNDfpReactViewGroup extends ReactViewGroup {
+    private String adUnitId = null;
+    private ReadableMap customTargeting = null;
+
+    RNDfpReactViewGroup(Context context) {
+        super(context);
+    }
+
+    public void setAdUnitId(String adUnitId) {
+        this.adUnitId = adUnitId;
+    }
+
+    public String getAdUnitId() {
+        return this.adUnitId;
+    }
+
+    public void setCustomTargeting(ReadableMap customTargeting) {
+        this.customTargeting = customTargeting;
+    }
+
+    public ReadableMap getCustomTargeting() {
+        return this.customTargeting;
+    }
+}

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -51,7 +51,7 @@
 }
 
 -(void)loadBanner {
-    if (self.adUnitID && self.onSizeChange && self.onWillChangeAdSizeTo && (self.bannerSize || self.dimensions || self.adSizes)) {
+    if (self.adUnitID && self.customTargeting && self.onSizeChange && self.onWillChangeAdSizeTo && (self.bannerSize || self.dimensions || self.adSizes)) {
         GADAdSize size = GADAdSizeFromCGSize(CGSizeMake(0.0, 0.0));
         NSMutableArray *validAdSizes;
 
@@ -127,7 +127,7 @@
         }
 
         DFPRequest *request = [DFPRequest request];
-        
+
         if (self.testDeviceID) {
             if([self.testDeviceID isEqualToString:@"EMULATOR"]) {
                 request.testDevices = @[kGADSimulatorID];


### PR DESCRIPTION
Since the issue is only with Android, not sure I should change anything with iOS, but I did to match Android functionality since it is now always getting passed customTargeting as well. But I'm not sure it needs to be changed.